### PR TITLE
add cloud credential support

### DIFF
--- a/component/template.hbs
+++ b/component/template.hbs
@@ -1,30 +1,25 @@
 <section class="horizontal-form">
   {{#accordion-list showExpandAll=false as | al expandFn |}}
    {{#if (eq step 1)}}
-    <div class="box mt-20">
-      <h4>Account Access</h4>
-
-      <div class="row inline-form">
-        <div class="col span-6">
-          <label class="acc-label">API Token{{field-required}}</label>
-          {{#input-or-display editable=(not dataFetched) value=model.linodeConfig.token obfuscate=true}}
-            {{input type="password" name="password" value=model.linodeConfig.token classNames="form-control" placeholder="Your Linode APIv4 Token" }}
-          {{/input-or-display}}
-          <p class="text-info">Create a Personal Access Token using the
-            <a target="_blank" href="https://cloud.linode.com/profile/tokens" rel="nofollow noreferrer noopener">Linode Cloud Manager</a>
-          </p>
-        </div>
-      </div>
-    </div>
+      {{#accordion-list-item
+         title=(t "modalAddCloudKey.linode.token.label")
+         detail=(t "modalAddCloudKey.linode.token.help" htmlSafe=true)
+         expandAll=expandAll
+         expand=(action expandFn)
+         expandOnInit=true
+      }}
+        {{form-auth-cloud-credential
+          driverName=driverName
+          parseAndCollectErrors=(action "errorHandler")
+          primaryResource=primaryResource
+          cloudCredentials=cloudCredentials
+          finishAndSelectCloudCredential=(action "finishAndSelectCloudCredential")
+          progressStep=(action "authLinode")
+          cancel=(action "cancel")
+          createLabel="modalAddCloudKey.linode.authAccountButton"
+        }}
+      {{/accordion-list-item}}
     {{top-errors errors=errors}}
-    <div class="footer-actions">
-      {{#if gettingData}}
-        <button class="btn bg-primary btn-disabled"><i class="icon icon-spinner icon-spin"></i> {{t 'generic.loading'}}</button>
-      {{else}}
-        <button {{action "authLinode" }} class="btn bg-primary" disabled={{not model.linodeConfig.token}}>Next: Configure Instances</button>
-      {{/if}}
-      <button {{action "cancel"}} class="btn bg-transparent">{{t 'generic.cancel'}}</button>
-    </div>
   {{else}}
   {{#accordion-list showExpandAll=false as | al expandFn |}}
     {{!-- This line shows the driver title which you don't have to change it --}}


### PR DESCRIPTION
Use cloud credentials to store Linode API Tokens.  These can be reused between node, global dns, cluster, and potentially other services in Rancher.

When this is merged, a release v0.3.0 should be created and https://github.com/rancher/rancher/pull/20281 should reference the updated version.

--
Closes #6 

Depends on https://github.com/rancher/rancher/pull/20281 and https://github.com/rancher/ui/pull/2834