### PR TITLE
fix: Add placeholder to root password field

### DIFF
--- a/component/template.hbs
+++ b/component/template.hbs
@@ -91,6 +91,7 @@
               type="password"
               classNames="form-control"
               value=model.linodeConfig.rootPass
+              placeholder="aComplexP@ssword"
             }}
           </div>
           <div class="col span-12">


### PR DESCRIPTION
This change adds a placeholder password to the root password field when configuring a Linode Node Driver template. This currently does not include any form of root password validation due to the [zxcvbn](https://github.com/dropbox/zxcvbn) dependency.