### PR TITLE
Bump default image to Ubuntu 22.04 and default region to us-iad

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -49,8 +49,8 @@ export default Ember.Component.extend(NodeDriver, {
     let config = get(this, 'globalStore').createRecord({
       type: '%%DRIVERNAME%%Config',
       instanceType: 'g6-standard-4', // 4 GB Ram
-      region: 'us-east', // Newark
-      image: 'linode/ubuntu18.04', // 10 year support from Ubuntu
+      region: 'us-iad', // Newark
+      image: 'linode/ubuntu22.04', // 10 year support from Ubuntu
       uaPrefix: 'Rancher',
       tags: '',
       authorizedUsers: '',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('createArtifact', gulp.series(function () {
   const json = JSON.parse(fs.readFileSync('./package.json'));
   const version = `v${json.version}`;
 
-  return gulp.src(['./dist/*', './releases/v0.2.0/linode-addons.yml'])
+  return gulp.src(['./dist/*', './releases/v0.6.0/linode-addons.yml'])
     .pipe(gulp.dest(`./releases/${version}`));
 }));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-driver-linode",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Rancher UI driver for the Linode docker-machine driver",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 📝 Description

This change updates the default image to `Ubuntu 22.04 LTS` and the default region to `us-iad` when creating Linode/RKE1 node templates. This is necessary because the previous default (`Ubuntu 18.04 LTS`) is outdated and the previous region (`us-east`) is a legacy compute region that we are looking to move away from.

Once this PR has been merged we should cut a release and put up a corresponding PR to bump the driver upstream.

See https://github.com/rancher/rancher/issues/44179

## ✔️ How to Test

The following manual testing steps assume you have provisioned a Rancher instance using Docker (named `rancher`) and have cloned this repository onto a development Linode.

1. Enter the project directory:

```bash
cd rancher-ui-driver-linode
```

2. Build the UI driver:

```bash
npm run build
```

3. Copy the built UI driver into the running Rancher instance:

```bash
docker cp ./dist/. rancher:/usr/share/rancher/ui/assets/rancher-ui-driver-linode
```

4. Navigate to the RKE1/Linode cluster creation in the web UI of your Rancher instance:

```
https://my.rancher.instance/dashboard/c/_/manager/provisioning.cattle.io.cluster/create?type=linode
```

5. Attempt to add a node template.
6. Ensure the default selected image is `Ubuntu 22.04 LTS` and the default selected region is `US-Mia (US)`.
7. Provision a cluster with these defaults and ensure the cluster becomes ready.

## 📷 Preview

<img width="1051" alt="Rancher" src="https://github.com/linode/rancher-ui-driver-linode/assets/114949949/cae2d1e6-2be3-401b-af6c-e9850d1f9469">
